### PR TITLE
Fix SG rule leak in daily-jobs action

### DIFF
--- a/daily-jobs/action.yml
+++ b/daily-jobs/action.yml
@@ -61,12 +61,14 @@ runs:
       shell: bash
       run: |
         MY_IP=$(curl -sf https://checkip.amazonaws.com)
+        echo "RUNNER_IP=${MY_IP}" >> $GITHUB_ENV
+        echo "Adding runner IP ${MY_IP}/32 to security group ${{ inputs.DB_SG }}"
         aws ec2 authorize-security-group-ingress \
           --group-id ${{ inputs.DB_SG }} \
           --protocol tcp \
           --port 5432 \
           --cidr ${MY_IP}/32 \
-          --region ${{ inputs.AWS_REGION }} || true
+          --region ${{ inputs.AWS_REGION }}
 
     - name: Install dependencies
       shell: bash
@@ -83,3 +85,17 @@ runs:
         set +o allexport
         bundle exec rake daily_jobs:run[${{ inputs.TIMEZONE }},${{ inputs.ENVIRONMENT }}]
       shell: bash
+
+    - name: Remove public IP from AWS security group
+      if: always()
+      shell: bash
+      run: |
+        if [ -n "${{ env.RUNNER_IP }}" ]; then
+          echo "Removing runner IP ${{ env.RUNNER_IP }}/32 from security group ${{ inputs.DB_SG }}"
+          aws ec2 revoke-security-group-ingress \
+            --group-id ${{ inputs.DB_SG }} \
+            --protocol tcp \
+            --port 5432 \
+            --cidr ${{ env.RUNNER_IP }}/32 \
+            --region ${{ inputs.AWS_REGION }} || true
+        fi


### PR DESCRIPTION
## Summary
- Security groups accumulated `/32` runner IP rules without cleanup, hitting AWS 60-rule limit
- This caused `Connection timed out` errors for daily jobs across multiple environments (Production, SMBC, MAI, Hypertherm, Westfund, Wannon Water, CAAT, Geelong Port)
- Added cleanup step (`if: always()`) to remove runner IP from SG after job completes
- Removed `|| true` from authorize step so SG errors are visible in logs

## Root cause
The `authorize-security-group-ingress` step added the runner's public IP to the RDS security group before each run, but never removed it. Over time all SGs filled up to the 60-rule AWS default limit. New IPs couldn't be added (error swallowed by `|| true`), so runners couldn't reach the database.

## Test plan
- [x] Manually clean stale `/32` rules from all affected SGs
- [x] Trigger a manual `workflow_dispatch` run on `review` or `staging`
- [x] Verify IP is added before job and removed after job in logs
- [x] Verify SG rule count stays stable after multiple runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)