### PR TITLE
Fix scheduled SG rule cleanup

### DIFF
--- a/company-snapshot/action.yml
+++ b/company-snapshot/action.yml
@@ -53,12 +53,17 @@ runs:
       shell: bash
       run: |
         MY_IP=$(curl -sf https://checkip.amazonaws.com)
-        aws ec2 authorize-security-group-ingress \
+        echo "Adding runner IP ${MY_IP}/32 to security group ${{ inputs.DB_SG }}"
+        SECURITY_GROUP_RULE_ID=$(aws ec2 authorize-security-group-ingress \
           --group-id ${{ inputs.DB_SG }} \
           --protocol tcp \
           --port 5432 \
           --cidr ${MY_IP}/32 \
-          --region ${{ inputs.AWS_REGION }} || true
+          --region ${{ inputs.AWS_REGION }} \
+          --query 'SecurityGroupRules[0].SecurityGroupRuleId' \
+          --output text)
+        echo "RUNNER_IP=${MY_IP}" >> $GITHUB_ENV
+        echo "SECURITY_GROUP_RULE_ID=${SECURITY_GROUP_RULE_ID}" >> $GITHUB_ENV
     - name: Install dependencies
       shell: bash
       working-directory: ${{ inputs.WORKING_DIR }}
@@ -75,3 +80,22 @@ runs:
          # purge all snapshots older than 90 days
          bundle exec rake company_snapshots:data_purge_company_snapshot
       shell: bash
+    - name: Remove public IP from AWS security group
+      if: always()
+      shell: bash
+      run: |
+        if [ -n "${SECURITY_GROUP_RULE_ID:-}" ] && [ "$SECURITY_GROUP_RULE_ID" != "None" ]; then
+          echo "Removing runner security group rule ${SECURITY_GROUP_RULE_ID} from security group ${{ inputs.DB_SG }}"
+          aws ec2 revoke-security-group-ingress \
+            --group-id ${{ inputs.DB_SG }} \
+            --security-group-rule-ids "$SECURITY_GROUP_RULE_ID" \
+            --region ${{ inputs.AWS_REGION }} || true
+        elif [ -n "${RUNNER_IP:-}" ]; then
+          echo "Removing runner IP ${RUNNER_IP}/32 from security group ${{ inputs.DB_SG }}"
+          aws ec2 revoke-security-group-ingress \
+            --group-id ${{ inputs.DB_SG }} \
+            --protocol tcp \
+            --port 5432 \
+            --cidr ${RUNNER_IP}/32 \
+            --region ${{ inputs.AWS_REGION }} || true
+        fi

--- a/daily-jobs/action.yml
+++ b/daily-jobs/action.yml
@@ -61,14 +61,17 @@ runs:
       shell: bash
       run: |
         MY_IP=$(curl -sf https://checkip.amazonaws.com)
-        echo "RUNNER_IP=${MY_IP}" >> $GITHUB_ENV
         echo "Adding runner IP ${MY_IP}/32 to security group ${{ inputs.DB_SG }}"
-        aws ec2 authorize-security-group-ingress \
+        SECURITY_GROUP_RULE_ID=$(aws ec2 authorize-security-group-ingress \
           --group-id ${{ inputs.DB_SG }} \
           --protocol tcp \
           --port 5432 \
           --cidr ${MY_IP}/32 \
-          --region ${{ inputs.AWS_REGION }}
+          --region ${{ inputs.AWS_REGION }} \
+          --query 'SecurityGroupRules[0].SecurityGroupRuleId' \
+          --output text)
+        echo "RUNNER_IP=${MY_IP}" >> $GITHUB_ENV
+        echo "SECURITY_GROUP_RULE_ID=${SECURITY_GROUP_RULE_ID}" >> $GITHUB_ENV
 
     - name: Install dependencies
       shell: bash
@@ -90,12 +93,18 @@ runs:
       if: always()
       shell: bash
       run: |
-        if [ -n "${{ env.RUNNER_IP }}" ]; then
-          echo "Removing runner IP ${{ env.RUNNER_IP }}/32 from security group ${{ inputs.DB_SG }}"
+        if [ -n "${SECURITY_GROUP_RULE_ID:-}" ] && [ "$SECURITY_GROUP_RULE_ID" != "None" ]; then
+          echo "Removing runner security group rule ${SECURITY_GROUP_RULE_ID} from security group ${{ inputs.DB_SG }}"
+          aws ec2 revoke-security-group-ingress \
+            --group-id ${{ inputs.DB_SG }} \
+            --security-group-rule-ids "$SECURITY_GROUP_RULE_ID" \
+            --region ${{ inputs.AWS_REGION }} || true
+        elif [ -n "${RUNNER_IP:-}" ]; then
+          echo "Removing runner IP ${RUNNER_IP}/32 from security group ${{ inputs.DB_SG }}"
           aws ec2 revoke-security-group-ingress \
             --group-id ${{ inputs.DB_SG }} \
             --protocol tcp \
             --port 5432 \
-            --cidr ${{ env.RUNNER_IP }}/32 \
+            --cidr ${RUNNER_IP}/32 \
             --region ${{ inputs.AWS_REGION }} || true
         fi

--- a/weekly-cron-job/action.yml
+++ b/weekly-cron-job/action.yml
@@ -53,12 +53,17 @@ runs:
       shell: bash
       run: |
         MY_IP=$(curl -sf https://checkip.amazonaws.com)
-        aws ec2 authorize-security-group-ingress \
+        echo "Adding runner IP ${MY_IP}/32 to security group ${{ inputs.DB_SG }}"
+        SECURITY_GROUP_RULE_ID=$(aws ec2 authorize-security-group-ingress \
           --group-id ${{ inputs.DB_SG }} \
           --protocol tcp \
           --port 5432 \
           --cidr ${MY_IP}/32 \
-          --region ${{ inputs.AWS_REGION }} || true
+          --region ${{ inputs.AWS_REGION }} \
+          --query 'SecurityGroupRules[0].SecurityGroupRuleId' \
+          --output text)
+        echo "RUNNER_IP=${MY_IP}" >> $GITHUB_ENV
+        echo "SECURITY_GROUP_RULE_ID=${SECURITY_GROUP_RULE_ID}" >> $GITHUB_ENV
     - name: Install dependencies
       shell: bash
       working-directory: ${{ inputs.WORKING_DIR }}
@@ -75,3 +80,22 @@ runs:
         bundle exec rake project_snapshot:project
         bundle exec rake ai:cleanup_chat_logs
       shell: bash
+    - name: Remove public IP from AWS security group
+      if: always()
+      shell: bash
+      run: |
+        if [ -n "${SECURITY_GROUP_RULE_ID:-}" ] && [ "$SECURITY_GROUP_RULE_ID" != "None" ]; then
+          echo "Removing runner security group rule ${SECURITY_GROUP_RULE_ID} from security group ${{ inputs.DB_SG }}"
+          aws ec2 revoke-security-group-ingress \
+            --group-id ${{ inputs.DB_SG }} \
+            --security-group-rule-ids "$SECURITY_GROUP_RULE_ID" \
+            --region ${{ inputs.AWS_REGION }} || true
+        elif [ -n "${RUNNER_IP:-}" ]; then
+          echo "Removing runner IP ${RUNNER_IP}/32 from security group ${{ inputs.DB_SG }}"
+          aws ec2 revoke-security-group-ingress \
+            --group-id ${{ inputs.DB_SG }} \
+            --protocol tcp \
+            --port 5432 \
+            --cidr ${RUNNER_IP}/32 \
+            --region ${{ inputs.AWS_REGION }} || true
+        fi


### PR DESCRIPTION
## Summary
- Capture the AWS security group rule ID when scheduled jobs authorize the GitHub runner IP.
- Revoke the exact rule in an `always()` cleanup step for daily, weekly, and company snapshot actions.
- Stop masking weekly/company-snapshot SG authorization failures so DB access issues fail at the real cause.

## Root cause
Weekly cron and company snapshot actions were adding DB SG ingress rules without cleanup, and `|| true` hid SG limit failures until the jobs later timed out on Postgres.

## Verification
- `git diff --check`
- `GEM_HOME=/tmp/empty-gems GEM_PATH= RBENV_VERSION=3.2.4 ruby -e 'require "yaml"; %w[daily-jobs/action.yml weekly-cron-job/action.yml company-snapshot/action.yml].each { |f| YAML.load_file(f); puts "OK #{f}" }'`