### PR TITLE
Source Netlify authentication from GitHub Actions secrets

### DIFF
--- a/netlify/action.yml
+++ b/netlify/action.yml
@@ -28,6 +28,9 @@ inputs:
   BRYNTUM_AUTH_TOKEN:
     description: bryntum auth token
     required: true
+  NETLIFY_AUTH_TOKEN:
+    description: Netlify personal access token
+    required: true
 runs:
   using: composite
   steps:
@@ -67,19 +70,27 @@ runs:
     - name: Deploy
       shell: bash
       working-directory: ${{ inputs.WORKING_DIR }}
+      env:
+        NETLIFY_AUTH_TOKEN: ${{ inputs.NETLIFY_AUTH_TOKEN }}
       run: |
+        trap 'rm -f .env .env.runtime .env.netlify' EXIT
         aws s3 cp s3://acutity-env/frontend/${{ inputs.ENVIRONMENT }} ./.env
         echo REACT_APP_GITHUB_SHA=${{ github.sha }} >> .env
+        grep -vE '^[[:space:]]*NETLIFY_AUTH_TOKEN=' .env > .env.runtime
         set -o allexport
-        source .env
+        source .env.runtime
         set +o allexport
         if [ -z "${NETLIFY_SITE_ID:-}" ]; then
           echo "NETLIFY_SITE_ID is missing in frontend/${{ inputs.ENVIRONMENT }} env file"
           exit 1
         fi
         netlify link --id "$NETLIFY_SITE_ID"
-        grep -v '^NETLIFY_SITE_ID=' .env > .env.netlify
-        netlify env:import .env.netlify
+        grep -vE '^[[:space:]]*(NETLIFY_SITE_ID|NETLIFY_AUTH_TOKEN)=' .env > .env.netlify
+        if ! netlify env:import .env.netlify > /dev/null 2>&1; then
+          echo "Failed to import Netlify environment variables"
+          exit 1
+        fi
+        echo "Netlify environment variables imported"
         netlify deploy -p
     - name: Post to a Slack channel
       id: slack


### PR DESCRIPTION
## Why?

Netlify authentication should not depend on shared S3 frontend environment files or appear in environment import output during deployments.

## Brief

Accept the Netlify authentication token as an explicit composite action input and keep it separate from application runtime environment variables.

## Goals

- Authenticate Netlify deployments with a GitHub Actions secret
- Preserve environment-specific Netlify site selection from the S3 configuration
- Prevent deployment credentials and imported environment values from appearing in logs
- Remain compatible while legacy S3 files are being cleaned

## Summary

- Added a required NETLIFY_AUTH_TOKEN input to the Netlify composite action
- Ensured the GitHub-provided token takes precedence over any legacy S3 value
- Excluded Netlify credentials and site identifiers from Netlify environment imports
- Suppressed import output and removed temporary environment files after deployment
- Published the tested action as v6.0.51

## Testing

- Composite action YAML parsing passed
- Token precedence and environment filtering smoke tests passed
- Acuity staging deployment completed successfully using v6.0.51

## Risks

- Callers must provide the new required secret input before adopting v6.0.51
- The PR remains a draft until the related Acuity architecture update is ready to merge